### PR TITLE
exclude node_modules from babel-loader

### DIFF
--- a/bundler/<REPLACE>config.js
+++ b/bundler/<REPLACE>config.js
@@ -25,11 +25,12 @@ module.exports = {
       },
       {
         test: /\.s?css$/,
-        loader: 'style!css!postcss!sass',
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        loader: 'style!css!postcss!sass'
       },
       {
         test: /\.js$/,
+        exclude: /node_modules/,
         loader: 'babel',
         query: {
           presets: ['latest']


### PR DESCRIPTION
slows down code bundling significantly to apply to all node_modules,
which shouldn't be done (they should be transpiled before published)

@Ledoux Can you merge and publish new version? Thanks!